### PR TITLE
Fix: Enable Password Strength Tool in All Tools Tab

### DIFF
--- a/website/components/network-admin/tabs/all.php
+++ b/website/components/network-admin/tabs/all.php
@@ -107,9 +107,9 @@
             </div>
             <div class="card-body">
                 <p>Test password strength and generate secure passwords.</p>
-                <div class="btn btn-outline-primary disabled">
-                    <i class="fas fa-key me-2"></i>Coming Soon
-                </div>
+                <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#passwordStrengthModal">
+                    <i class="fas fa-key me-2"></i>Use Tool
+                </button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- Fixed the password strength tool to be accessible from both the Security tab and All Tools tab
- The tool was already fully implemented but was incorrectly showing "Coming Soon" in the All Tools tab
- Changed the disabled placeholder button to the functional modal trigger button

## Implementation Details
The password strength tester and generator was previously implemented with:
- Real-time password strength analysis with entropy calculation
- Visual strength meter with color-coded feedback  
- Secure password generation using Web Crypto API
- Password history (session-only) with copy-to-clipboard functionality
- Accessibility features and keyboard navigation support

The issue was simply that the "All Tools" tab still showed a "Coming Soon" placeholder instead of the working button that was already present in the "Security" tab.

## Test Plan
- [x] Verify password strength tool opens from Security tab
- [x] Verify password strength tool opens from All Tools tab  
- [x] Test password strength analysis functionality
- [x] Test password generation with various options
- [x] Verify copy-to-clipboard functionality works
- [x] Test accessibility features

## Files Changed
- `website/components/network-admin/tabs/all.php` - Updated button to enable password tool

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)